### PR TITLE
Mll section summaries

### DIFF
--- a/_ext/cgns_function_summary.py
+++ b/_ext/cgns_function_summary.py
@@ -2,17 +2,46 @@ from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
 from sphinx.addnodes import pending_xref
 from pathlib import Path
+import re
 
 class CGNSExtractDoxygenFunctionsDirective(SphinxDirective):
+    """
+    A Sphinx directive to extract function names and their brief descriptions
+    from Doxygen-generated XML files. The extracted information is displayed as
+    a nested bullet list in the documentation.
+
+    Arguments:
+        group_name (str): The name of the group, used to locate the
+            corresponding Doxygen XML file. This is the first required argument.
+            The group_name is the same as used for the doxygengroup directive.
+            The XML file is expected to be at xml/group__{group_name} where
+            any underscores in group_name are repeated (so they appear twice).
+            A link is expected elsewhere in the rst file with the format
+            .. _{group_name}-ref:
+        group_name_display_text (str, optional): A custom display text for the
+            group name in the generated documentation. If not provided, a
+            formatted version of `group_name` is used.
+
+    Usage:
+        .. cgns-group-function-summary:: DataArrays
+
+            The group name is formatted as Data Arrays.  The xml file is
+            xml/group__DataArrays.xml.
+
+        .. cgns-group-function-summary:: CGNSFile Opening and Closing a CGNS File
+
+            The group name is Opening and Closing a CGNS File.  The xml file is
+            xml/group__CGNSFile.xml.
+    """
     required_arguments = 1  # Argument for group name
-    optional_arguments = 0
-    final_argument_whitespace = False
+    optional_arguments = 1
+    final_argument_whitespace = True
     option_spec = {}
 
     def run(self):
         # Get the group name from the directive argument
         group_name = self.arguments[0]
-        xml_file = f"group__{group_name}.xml"
+        xml_file = f"group__{group_name.replace('_', '__')}.xml"
         full_path = Path(self.env.app.confdir) / 'xml' / xml_file
 
         # Check if the XML file exists
@@ -38,10 +67,12 @@ class CGNSExtractDoxygenFunctionsDirective(SphinxDirective):
         group_ref = pending_xref('', refdomain='std', reftype='ref',
                                  reftarget=f"{group_name.lower()}-ref",
                                  refexplicit=True)
-        # The name we want to display
-        group_name_display_text = ''.join([' ' + char if char.isupper() and
-                                           i > 0 else char for i, char in
-                                           enumerate(group_name)])
+        # Format the group name for display by adding a space before each
+        # capital letter after the first.
+        group_name_display_text = (
+            self.arguments[1] if len(self.arguments) > 1 else ''.join(
+                [' ' + char if char.isupper() and i > 0 else char
+                 for i, char in enumerate(group_name)]))
         group_ref += nodes.Text(group_name_display_text)
         group_paragraph += group_ref
         group_item += group_paragraph
@@ -62,8 +93,8 @@ class CGNSExtractDoxygenFunctionsDirective(SphinxDirective):
             if func_desc:
                 func_paragraph += nodes.Text(f" - {func_desc}")
             else:
-                func_paragraph += nodes.Text(" - ⚠️ No description "
-                                             "provided.")
+                func_paragraph += nodes.Text(
+                    " - ⚠️ No description provided.")
             func_item += func_paragraph
             sublist += func_item
 
@@ -73,77 +104,92 @@ class CGNSExtractDoxygenFunctionsDirective(SphinxDirective):
 
         return [bullet_list]
 
-    def _extract_functions(self, file_path):
+    def _extract_functions(self, file_path: Path) -> list[tuple[str, str]]:
         """
         Scan the XML file and extract function names and descriptions.
+        Only considers <name> and <briefdescription> tags within a
+        <memberdef kind="function"> block.
         """
         functions = []
         with file_path.open("r") as file:
             func_name = None
             func_desc = None
             inside_brief = False
+            inside_func = False
             buffer = []  # Buffer for handling multi-line <para> content
 
             for line in file:
-                # Look for function name
-                if "<name>" in line:
-                    # Name found without brief description
-                    if func_name is not None:
-                        functions.append((func_name, ""))
-                    # Issue warning if inside brief
-                    if inside_brief:
-                        self.state_machine.reporter.warning(
-                            "Invalid XML structure: <name> tag found inside "
-                            "<briefdescription>.  This indicates a malformed "
-                            "XML file.  Previous description discarded.",
-                            line=self.lineno)
+                # Detect start of <memberdef kind="function">
+                if '<memberdef kind="function"' in line:
+                    inside_func = True
+
+                # Process content only if inside a function definition
+                elif inside_func:
+                    # Detect end of </memberdef>
+                    if '</memberdef>' in line:
+                        inside_func = False
+
+                    # Look for function name
+                    elif "<name>" in line:
+                        # Name found without brief description
+                        if func_name is not None:
+                            functions.append((func_name, ""))
+                        # Issue warning if inside brief
+                        if inside_brief:
+                            self.state_machine.reporter.warning(
+                                "Invalid XML structure: <name> tag found "
+                                "inside <briefdescription>.  This indicates a "
+                                "malformed XML file.  Previous description "
+                                "discarded.",
+                                line=self.lineno)
+                            inside_brief = False
+                        func_name = self._extract_tag_content(line, "name")
+
+                    # Detect start of <briefdescription>
+                    elif "<briefdescription>" in line:
+                        if inside_brief:
+                            self.state_machine.reporter.warning(
+                                "Invalid XML structure: found nested "
+                                "<briefdescription>.  This indicates a "
+                                "malformed XML file.",
+                                line=self.lineno)
+                        if func_name is None:
+                            self.state_machine.reporter.warning(
+                                "Invalid XML structure: found "
+                                "<briefdescription> without function name.  "
+                                "This indicates a malformed XML file.",
+                                line=self.lineno)
+                        inside_brief = True
+                        buffer = []
+
+                    # Detect end of <briefdescription>
+                    elif "</briefdescription>" in line:
+                        if not inside_brief:
+                            self.state_machine.reporter.warning(
+                                "Invalid XML structure: found "
+                                "</briefdescription> before "
+                                "<briefdescription>.  This indicates a "
+                                "malformed XML file.",
+                                line=self.lineno)
+                        elif func_name is None:
+                            self.state_machine.reporter.warning(
+                                "Invalid XML structure: found "
+                                "</briefdescription> without function name.  "
+                                "This indicates a malformed XML file.",
+                                line=self.lineno)
+                        else:
+                            # Extract the brief description from buffered <para>
+                            # content
+                            func_desc = self._extract_tag_content(
+                                "".join(buffer), "para")
+                            functions.append((func_name, func_desc or ""))
                         inside_brief = False
-                    func_name = self._extract_tag_content(line, "name")
+                        func_name = None
+                        func_desc = None
 
-                # Detect start of <briefdescription>
-                elif "<briefdescription>" in line:
-                    if inside_brief:
-                        warning = self.state_machine.reporter.warning(
-                            "Invalid XML structure: found nested "
-                            "<briefdescription>.  This indicates a malformed "
-                            "XML file.",
-                            line=self.lineno)
-                    if func_name is None:
-                        warning = self.state_machine.reporter.warning(
-                            "Invalid XML structure: found <briefdescription> "
-                            "without function name.  This indicates a "
-                            "malformed XML file.",
-                            line=self.lineno)
-                    inside_brief = True
-                    buffer = []
-
-                # Detect end of <briefdescription>
-                elif "</briefdescription>" in line:
-                    if not inside_brief:
-                        warning = self.state_machine.reporter.warning(
-                            "Invalid XML structure: found </briefdescription> "
-                            "before <briefdescription>.  This indicates a "
-                            "malformed XML file.",
-                            line=self.lineno)
-                    elif func_name is None:
-                        warning = self.state_machine.reporter.warning(
-                            "Invalid XML structure: found </briefdescription> "
-                            "without function name.  This indicates a "
-                            "malformed XML file.",
-                            line=self.lineno)
-                    else:
-                        # Extract the brief description from buffered <para>
-                        # content
-                        func_desc = self._extract_tag_content("".join(buffer),
-                                                              "para")
-                        functions.append((func_name, func_desc or ""))
-                    inside_brief = False
-                    func_name = None
-                    func_desc = None
-
-                # Collect lines inside <briefdescription>
-                elif inside_brief:
-                    buffer.append(line)
+                    # Collect lines inside <briefdescription>
+                    elif inside_brief:
+                        buffer.append(line)
 
             # If we ended with a name and no description, save the name
             if func_name is not None:
@@ -151,14 +197,18 @@ class CGNSExtractDoxygenFunctionsDirective(SphinxDirective):
 
         return functions
 
-    def _extract_tag_content(self, text, tag):
+    def _extract_tag_content(self, text: str, tag: str) -> str:
         """
         Extract content between <tag> and </tag>, handling multi-line tags.
+        Removes any nested tags found within the extracted content.
         """
         start = text.find(f"<{tag}>")
         end = text.find(f"</{tag}>")
         if start != -1 and end != -1:
-            return text[start + len(f"<{tag}>") : end].strip()
+            content = text[start + len(f"<{tag}>") : end].strip()
+            # Remove any nested tags
+            content = re.sub(r"<[^>]+>", "", content)
+            return content
         return ""
 
 def setup(app):

--- a/_ext/cgns_function_summary.py
+++ b/_ext/cgns_function_summary.py
@@ -1,0 +1,171 @@
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from sphinx.addnodes import pending_xref
+from pathlib import Path
+
+class CGNSExtractDoxygenFunctionsDirective(SphinxDirective):
+    required_arguments = 1  # Argument for group name
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {}
+
+    def run(self):
+        # Get the group name from the directive argument
+        group_name = self.arguments[0]
+        xml_file = f"group__{group_name}.xml"
+        full_path = Path(self.env.app.confdir) / 'xml' / xml_file
+
+        # Check if the XML file exists
+        if not full_path.exists():
+            error = self.state_machine.reporter.error(
+                f"File not found: {xml_file}",
+                nodes.literal_block(self.block_text, self.block_text),
+                line=self.lineno,
+            )
+            return [error]
+
+        # Extract function names and descriptions
+        functions = self._extract_functions(full_path)
+
+        # Create a bullet list node for the group
+        bullet_list = nodes.bullet_list()
+
+        # Create the main list item for the group name
+        group_item = nodes.list_item()
+        group_paragraph = nodes.paragraph()
+
+        # Add the group name as a reference
+        group_ref = pending_xref('', refdomain='std', reftype='ref',
+                                 reftarget=f"{group_name.lower()}-ref",
+                                 refexplicit=True)
+        # The name we want to display
+        group_name_display_text = ''.join([' ' + char if char.isupper() and
+                                           i > 0 else char for i, char in
+                                           enumerate(group_name)])
+        group_ref += nodes.Text(group_name_display_text)
+        group_paragraph += group_ref
+        group_item += group_paragraph
+
+        # Create a sublist for the functions
+        sublist = nodes.bullet_list()
+
+        for func_name, func_desc in functions:
+            # Create a list item for each function
+            func_item = nodes.list_item()
+            func_paragraph = nodes.paragraph()
+
+            # Create a cross-reference node for :cpp:func:
+            xref = pending_xref('', refdomain='cpp', reftype='func',
+                                reftarget=func_name, refexplicit=True)
+            xref += nodes.literal('', func_name)
+            func_paragraph += xref
+            if func_desc:
+                func_paragraph += nodes.Text(f" - {func_desc}")
+            else:
+                func_paragraph += nodes.Text(" - ⚠️ No description "
+                                             "provided.")
+            func_item += func_paragraph
+            sublist += func_item
+
+        # Add the sublist to the group item
+        group_item += sublist
+        bullet_list += group_item
+
+        return [bullet_list]
+
+    def _extract_functions(self, file_path):
+        """
+        Scan the XML file and extract function names and descriptions.
+        """
+        functions = []
+        with file_path.open("r") as file:
+            func_name = None
+            func_desc = None
+            inside_brief = False
+            buffer = []  # Buffer for handling multi-line <para> content
+
+            for line in file:
+                # Look for function name
+                if "<name>" in line:
+                    # Name found without brief description
+                    if func_name is not None:
+                        functions.append((func_name, ""))
+                    # Issue warning if inside brief
+                    if inside_brief:
+                        self.state_machine.reporter.warning(
+                            "Invalid XML structure: <name> tag found inside "
+                            "<briefdescription>.  This indicates a malformed "
+                            "XML file.  Previous description discarded.",
+                            line=self.lineno)
+                        inside_brief = False
+                    func_name = self._extract_tag_content(line, "name")
+
+                # Detect start of <briefdescription>
+                elif "<briefdescription>" in line:
+                    if inside_brief:
+                        warning = self.state_machine.reporter.warning(
+                            "Invalid XML structure: found nested "
+                            "<briefdescription>.  This indicates a malformed "
+                            "XML file.",
+                            line=self.lineno)
+                    if func_name is None:
+                        warning = self.state_machine.reporter.warning(
+                            "Invalid XML structure: found <briefdescription> "
+                            "without function name.  This indicates a "
+                            "malformed XML file.",
+                            line=self.lineno)
+                    inside_brief = True
+                    buffer = []
+
+                # Detect end of <briefdescription>
+                elif "</briefdescription>" in line:
+                    if not inside_brief:
+                        warning = self.state_machine.reporter.warning(
+                            "Invalid XML structure: found </briefdescription> "
+                            "before <briefdescription>.  This indicates a "
+                            "malformed XML file.",
+                            line=self.lineno)
+                    elif func_name is None:
+                        warning = self.state_machine.reporter.warning(
+                            "Invalid XML structure: found </briefdescription> "
+                            "without function name.  This indicates a "
+                            "malformed XML file.",
+                            line=self.lineno)
+                    else:
+                        # Extract the brief description from buffered <para>
+                        # content
+                        func_desc = self._extract_tag_content("".join(buffer),
+                                                              "para")
+                        functions.append((func_name, func_desc or ""))
+                    inside_brief = False
+                    func_name = None
+                    func_desc = None
+
+                # Collect lines inside <briefdescription>
+                elif inside_brief:
+                    buffer.append(line)
+
+            # If we ended with a name and no description, save the name
+            if func_name is not None:
+                functions.append((func_name, ""))
+
+        return functions
+
+    def _extract_tag_content(self, text, tag):
+        """
+        Extract content between <tag> and </tag>, handling multi-line tags.
+        """
+        start = text.find(f"<{tag}>")
+        end = text.find(f"</{tag}>")
+        if start != -1 and end != -1:
+            return text[start + len(f"<{tag}>") : end].strip()
+        return ""
+
+def setup(app):
+    app.add_directive("cgns-group-function-summary",
+                      CGNSExtractDoxygenFunctionsDirective)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/conf.py
+++ b/conf.py
@@ -14,7 +14,9 @@
 # sys.path.insert(0, os.path.abspath('.'))
 from sphinx.builders.html import StandaloneHTMLBuilder
 import subprocess, os, sys
+from pathlib import Path
 sys.path.insert(0, os.path.abspath('.'))
+sys.path.append(str(Path('_ext').resolve()))
 
 # Doxygen
 subprocess.call('doxygen Doxyfile', shell=True)
@@ -47,7 +49,8 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinxfortran.fortran_domain',
     'sphinxfortran.fortran_autodoc',
-    'breathe'
+    'breathe',
+    'cgns_function_summary'
 ]
 # Prefix to add to ticket numbers to get the full URL to JIRA
 # see use in the News page

--- a/source/standard/MLL/api/c_api.rst
+++ b/source/standard/MLL/api/c_api.rst
@@ -101,10 +101,7 @@ ____________________________________________
 Error Handling
 **********************
 
-..
-  This section is small enough not to need a summary (archived docs did not have a summary here either).  Also, cg_get_error's brief description is not brief!
-..
-  cgns-group-function-summary:: ErrorHandling
+.. cgns-group-function-summary:: ErrorHandling
 
 .. doxygengroup:: ErrorHandling
     :content-only:

--- a/source/standard/MLL/api/c_api.rst
+++ b/source/standard/MLL/api/c_api.rst
@@ -10,11 +10,34 @@ These are all the types and functions available in the CGNS C API.
    Please refer to :ref:`MLLGeneralRemarks-ref` for details and conventions regarding
    the equivalent Fortran APIs, paying special attention to :ref:`CGNSFortranPort-ref`.
 
-.. _CGNSFile-ref:
-
 ******************************************
 File and Library Operations
 ******************************************
+
+.. cgns-group-function-summary:: CGNSFile Opening and Closing a CGNS File
+
+..
+  Because of the way internals is split into two groups, this summary of functions is done manually.  CGNSInternals_FNC_CG_CONFIG has no matching reference.  The manual implementation merges the output of the following:
+..
+  cgns-group-function-summary:: CGNSInternals_FNC_CG_CONFIG Configuring CGNS Internals
+..
+  cgns-group-function-summary:: CGNSInternals Configuring CGNS Internals
+
+* :ref:`Configuring CGNS Internals<CGNSInternals-ref>`
+
+  * :cpp:func:`cg_configure<cg_configure>` - Configure CGNS library internal options.
+  * :cpp:func:`cg_error_handler<cg_error_handler>` - Set CGNS error handler
+  * :cpp:func:`cg_set_compress<cg_set_compress>` - Set CGNS compression mode.
+  * :cpp:func:`cg_get_compress<cg_get_compress>` - Get CGNS compression mode.
+  * :cpp:func:`cg_set_path<cg_set_path>` - Set the CGNS link search path.
+  * :cpp:func:`cg_add_path<cg_add_path>` - Add to the CGNS link search path.
+
+.. cgns-group-function-summary:: CGNSInterfaceCGIO Interfacing with CGIO
+
+.. _CGNSFile-ref:
+
+CGNS File Operations
+____________________________________________
 
 .. doxygengroup:: CGNSFile
     :content-only:
@@ -48,6 +71,9 @@ ____________________________________________
 Navigating a CGNS File
 **********************
 
+.. cgns-group-function-summary:: AccessingANode
+.. cgns-group-function-summary:: DeletingANode
+
 .. _AccessingANode-ref:
 
 Accessing a Node
@@ -75,6 +101,11 @@ ____________________________________________
 Error Handling
 **********************
 
+..
+  This section is small enough not to need a summary (archived docs did not have a summary here either).  Also, cg_get_error's brief description is not brief!
+..
+  cgns-group-function-summary:: ErrorHandling
+
 .. doxygengroup:: ErrorHandling
     :content-only:
 
@@ -83,6 +114,10 @@ Error Handling
 **********************
 Structural Nodes
 **********************
+
+.. cgns-group-function-summary:: CGNSBaseInformation CGNS Base Information
+.. cgns-group-function-summary:: CGNSZoneInformation CGNS Zone Information
+.. cgns-group-function-summary:: SimulationType
 
 .. _CGNSBaseInformation-ref: 
 
@@ -249,6 +284,10 @@ _________________________________________________________________
 Location and Position
 **********************
 
+.. cgns-group-function-summary:: GridLocation
+.. cgns-group-function-summary:: PointSets
+.. cgns-group-function-summary:: RindLayers
+
 .. _GridLocation-ref:
 
 Grid Location
@@ -301,6 +340,13 @@ ____________________________________________
 **********************
 Auxiliary Data
 **********************
+
+.. cgns-group-function-summary:: ReferenceState
+.. cgns-group-function-summary:: Gravity
+.. cgns-group-function-summary:: ConvergenceHistory
+.. cgns-group-function-summary:: IntegralData
+.. cgns-group-function-summary:: UserDefinedData
+.. cgns-group-function-summary:: FreeingMemory
 
 .. _ReferenceState-ref:
 
@@ -386,6 +432,11 @@ ____________________________________________
 Grid Specification
 **********************
 
+.. cgns-group-function-summary:: ZoneGridCoordinates
+.. cgns-group-function-summary:: ElementConnectivity
+.. cgns-group-function-summary:: Axisymmetry
+.. cgns-group-function-summary:: RotatingCoordinates
+
 .. _ZoneGridCoordinates-ref:
 
 Zone Grid Coordinates
@@ -430,7 +481,7 @@ ____________________________________________
 
 ------
 
-.. _Rotating-ref:
+.. _RotatingCoordinates-ref:
 
 Rotating Coordinates
 ____________________________________________
@@ -448,6 +499,11 @@ ____________________________________________
 Solution Data
 **********************
 
+.. cgns-group-function-summary:: FlowSolution
+.. cgns-group-function-summary:: FlowSolutionData
+.. cgns-group-function-summary:: DiscreteData
+.. cgns-group-function-summary:: ZoneSubregions
+
 .. _FlowSolution-ref:
 
 Flow Solution
@@ -458,6 +514,16 @@ ____________________________________________
    <p><i>Node</i>:  <code>FlowSolution_t</code>
 
 .. doxygengroup:: FlowSolution
+    :content-only:
+
+------
+
+.. _FlowSolutionData-ref:
+
+Flow Solution Data
+____________________________________________
+
+.. doxygengroup:: FlowSolutionData
     :content-only:
 
 ------
@@ -493,6 +559,11 @@ ____________________________________________
 **********************
 Grid Connectivity
 **********************
+
+.. cgns-group-function-summary:: OneToOneConnectivity One-to-One Connectivity
+.. cgns-group-function-summary:: GeneralizedConnectivity
+.. cgns-group-function-summary:: SpecialGridConnectivityProperty
+.. cgns-group-function-summary:: OversetHoles
 
 .. _OneToOneConnectivity-ref:
 
@@ -554,6 +625,11 @@ ____________________________________________
 Boundary Conditions
 **********************
 
+.. cgns-group-function-summary:: BoundaryConditionType Boundary Condition Type and Location
+.. cgns-group-function-summary:: BoundaryConditionDatasets
+.. cgns-group-function-summary:: BCData Boundary Condition Data
+.. cgns-group-function-summary:: SpecialBoundaryConditionProperty Special Boundary Condition Properties
+
 .. _BoundaryConditionType-ref:
 
 Boundary Condition Type and Location
@@ -613,6 +689,13 @@ _________________________________________________________________
 **********************
 Equation Specification
 **********************
+
+.. cgns-group-function-summary:: FlowEquationSet
+.. cgns-group-function-summary:: ParticleEquationSet
+.. cgns-group-function-summary:: GoverningEquations
+.. cgns-group-function-summary:: ParticleGoverningEquations
+.. cgns-group-function-summary:: AuxiliaryModel
+.. cgns-group-function-summary:: ParticleModel
 
 .. _FlowEquationSet-ref:
 
@@ -701,6 +784,12 @@ ________________________________________________
 Families
 **********************
 
+.. cgns-group-function-summary:: CGNSFamilyDefinition Family Definition
+.. cgns-group-function-summary:: CGNSFamilyHierarchyTreeDefinition Family Hierarchy Tree
+.. cgns-group-function-summary:: CGNSGeometryReference Geometry Reference
+.. cgns-group-function-summary:: CGNSFamilyBoundaryCondition Family Boundary Condition
+.. cgns-group-function-summary:: FamilyName
+
 .. _CGNSFamilyDefinition-ref:
 
 Family Definition
@@ -729,7 +818,7 @@ ____________________________________________
 
 ------
 
-.. _CGNSGeometry-ref:
+.. _CGNSGeometryReference-ref:
 
 Geometry Reference
 ____________________________________________
@@ -774,6 +863,13 @@ ____________________________________________
 **********************
 Time-Dependent Data
 **********************
+
+.. cgns-group-function-summary:: BaseIterativeData
+.. cgns-group-function-summary:: ZoneIterativeData
+.. cgns-group-function-summary:: ParticleIterativeData
+.. cgns-group-function-summary:: RigidGridMotion
+.. cgns-group-function-summary:: ArbitraryGridMotion
+.. cgns-group-function-summary:: ZoneGridConnectivity
 
 .. _BaseIterativeData-ref:
 
@@ -876,6 +972,8 @@ ________________________________________________
 Links
 **********************
 
+.. cgns-group-function-summary:: Links
+
 .. _Links-ref:
 
 .. doxygengroup:: Links
@@ -885,6 +983,11 @@ Links
 **********************
 Particle Specification
 **********************
+
+.. cgns-group-function-summary:: ParticleZoneInformation
+.. cgns-group-function-summary:: ParticleCoordinates
+.. cgns-group-function-summary:: ParticleSolution
+.. cgns-group-function-summary:: ParticleSolutionData
 
 .. _ParticleZoneInformation-ref:
 
@@ -930,6 +1033,3 @@ ________________________________________________
 
 .. doxygengroup:: ParticleSolutionData
     :content-only:
-
-
-

--- a/source/standard/MLL/api/c_api.rst
+++ b/source/standard/MLL/api/c_api.rst
@@ -134,6 +134,9 @@ ____________________________________________
 Descriptors
 **********************
 
+.. cgns-group-function-summary:: DescriptiveText
+.. cgns-group-function-summary:: OrdinalValue
+
 .. _DescriptiveText-ref:
 
 Descriptive Text
@@ -166,6 +169,12 @@ ____________________________________________
 Physical Data
 **********************
 
+.. cgns-group-function-summary:: DataArrays
+.. cgns-group-function-summary:: DataClass
+.. cgns-group-function-summary:: DataConversionFactors
+.. cgns-group-function-summary:: DimensionalUnits
+.. cgns-group-function-summary:: DimensionalExponents
+
 .. _DataArrays-ref:
 
 Data Arrays
@@ -182,7 +191,7 @@ ____________________________________________
 
 .. _DataClass-ref:
 
-Data Class (DataClass_t)
+Data Class
 ____________________________________________
 
 .. raw:: html

--- a/source/standard/MLL/api/c_parallel_api.rst
+++ b/source/standard/MLL/api/c_parallel_api.rst
@@ -15,89 +15,111 @@ the associated routines. It utilizes MPI-IO through the HDF5 library to support
 parallel I/O operations. As a result, the CGNS library must be built with HDF5
 to enable the parallel CGNS APIs.
 
-******************************
-Parallel File Operations
-******************************
+.. cgns-group-function-summary:: ParallelFile File Operations
+.. cgns-group-function-summary:: ParallelGridCoordinate Grid Coordinate Data
+.. cgns-group-function-summary:: ParallelParticleCoordinate Particle Coordinate Data
+.. cgns-group-function-summary:: ElementConnectivityData
+.. cgns-group-function-summary:: SolutionData Flow Solution Data
+.. cgns-group-function-summary:: ParallelParticleSolutionData Particle Solution Data
+.. cgns-group-function-summary:: ArrayData
+.. cgns-group-function-summary:: ParallelMisc Miscellaneous Routines
+.. cgns-group-function-summary:: PointListData PointList Data
+
 
 .. _ParallelFile-ref:
+
+************************
+Parallel File Operations
+************************
 
 .. doxygengroup:: ParallelFile
     :content-only:
 
-******************************
-Parallel Grid Coordinate Data
-******************************
 
 .. _ParallelGridCoordinate-ref:
 
+*****************************
+Parallel Grid Coordinate Data
+*****************************
+
 .. doxygengroup:: ParallelGridCoordinate
     :content-only:
+
+
+.. _ParallelParticleCoordinate-ref:
 
 *********************************
 Parallel Particle Coordinate Data
 *********************************
 
-.. _ParallelParticleCoordinate-ref:
-
-Parallel Particle Coordinates
-________________________________________________
-
 .. doxygengroup:: ParallelParticleCoordinate
     :content-only:
 
-------
-
-*********************************************
-Parallel Element Connectivity Data
-*********************************************
 
 .. _ElementConnectivityData-ref:
+
+**********************************
+Parallel Element Connectivity Data
+**********************************
 
 .. doxygengroup:: ElementConnectivityData
     :content-only:
 
-******************************
+
+.. _SolutionData-ref:
+
+***************************
 Parallel Flow Solution Data
-******************************
+***************************
 
 .. note::
    The application is responsible for ensuring that the data type for the solution
    data matches that defined in the file; no conversions are done.
 
-.. _SolutionData-ref:
-
 .. doxygengroup:: SolutionData
     :content-only:
 
+
 .. _ParallelParticleSolutionData-ref:
 
+*******************************
 Parallel Particle Solution Data
-________________________________________________
+*******************************
+
+.. note::
+   The application is responsible for ensuring that the data type for the solution
+   data matches that defined in the file; no conversions are done.
 
 .. doxygengroup:: ParallelParticleSolutionData
     :content-only:
 
-------
-
-******************************
-Parallel Array Data
-******************************
 
 .. _ArrayData-ref:
+
+*******************
+Parallel Array Data
+*******************
 
 .. doxygengroup:: ArrayData
     :content-only:
 
-*********************************************
+
+*******************************
 Parallel Miscellaneous Routines
-*********************************************
+*******************************
 
 .. _ParallelMisc-ref:
+
+Miscellaneous Routines
+________________________________________________
 
 .. doxygengroup:: ParallelMisc
     :content-only:
 
+.. _PointListData-ref:
+
+PointList Data
+________________________________________________
+
 .. doxygengroup:: PointListData
     :content-only:
-
-


### PR DESCRIPTION
Creates summaries of MLL sections using a custom directive.  Tested on sphinx 5.3.0.  As requested, nearly all summaries are automatically produced from doxygen.  There are two exceptions:
- The doxygen for Configuring CGNS Internals was split in two so I just did this one manually.
- There is no summary for the Error Handling section primarily because one of the descriptions is not brief.  The archived MLL didn't have a summary for this section either.

Additional fixes:
- Added missing flow solution data functions to MLL documentation.
- Made references consistent with doxygen xml sources where different (in most cases these were consistent).
- Slightly restructured parallel api rst doc primarily to better position references.

Closes #13 